### PR TITLE
Use *floor* to avoid rounding to the upper value after dividing

### DIFF
--- a/glimpse-core/src/main/java/glimpse/core/BitmapExtensions.kt
+++ b/glimpse-core/src/main/java/glimpse/core/BitmapExtensions.kt
@@ -5,6 +5,7 @@ package glimpse.core
 import android.graphics.*
 import glimpse.core.ArrayUtils.generateEmptyTensor
 import org.tensorflow.lite.Interpreter
+import kotlin.math.floor
 import kotlin.math.max
 import kotlin.math.min
 
@@ -86,10 +87,14 @@ fun Bitmap.debugHeatMap(
         }
         .let { a ->
             val newBitmap = Bitmap
-                .createBitmap(scaledBitmap.width / 8, scaledBitmap.height / 8, Bitmap.Config.ARGB_8888)
+                .createBitmap(
+                    floor(scaledBitmap.width / 8f).toInt(),
+                    floor(scaledBitmap.height / 8f).toInt(),
+                    Bitmap.Config.ARGB_8888
+                )
 
             a.forEachIndexed { index, (value, focused) ->
-                val (pos_x, pos_y) = index % output[0][0][0].size to index / output[0][0][0].size
+                val (pos_x, pos_y) = index % output[0][0][0].size to floor(1.0 * index / output[0][0][0].size).toInt()
                 val (focus_x, focus_y) = focusArea.x * output[0][0][0].size to focusArea.y * output[0][0].size
                 val color = if (focus_x.toInt() == pos_x && focus_y.toInt() == pos_y) {
                     Color.rgb(255, 0, 0)

--- a/sample-app/src/androidTest/java/glimpse/sample/core/DebugHeatmapTest.kt
+++ b/sample-app/src/androidTest/java/glimpse/sample/core/DebugHeatmapTest.kt
@@ -1,0 +1,24 @@
+package glimpse.sample.core
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory.decodeResource
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.common.truth.Truth.assertThat
+import glimpse.core.debugHeatMap
+import org.junit.Test
+
+class DebugHeatmapTest {
+    private val context by lazy { InstrumentationRegistry.getInstrumentation().targetContext }
+    private val bitmap by lazy {
+        decodeResource(context.resources, glimpse.sample.R.drawable.original).let {
+            Bitmap.createScaledBitmap(it, 30, 20, false)
+        }
+    }
+
+    @Test
+    fun testFocalPoints() {
+        val heatMap = bitmap.debugHeatMap()
+        assertThat(heatMap.width).isEqualTo(320)
+        assertThat(heatMap.height).isEqualTo(240)
+    }
+}


### PR DESCRIPTION
closes https://github.com/the-super-toys/glimpse-android/issues/1

In that issue, there seems to be an indexOutOfBounds caused by the *pos_y*  value being too high.
This should fix it, though I was not able to reproduce the issue because it was reported with almost no info on how to reproduce it.