### PR TITLE
Make interpreter global and thread safe

### DIFF
--- a/glimpse-core/src/main/java/glimpse/core/BitmapExtensions.kt
+++ b/glimpse-core/src/main/java/glimpse/core/BitmapExtensions.kt
@@ -66,11 +66,8 @@ fun Bitmap.debugHeatMap(
     pixels.forEach { pixel -> inputBuffer.putFloat((pixel shr 16 and 0xFF) / 255f) }
     pixels.forEach { pixel -> inputBuffer.putFloat((pixel shr 8 and 0xFF) / 255f) }
     pixels.forEach { pixel -> inputBuffer.putFloat((pixel and 0xFF) / 255f) }
-    val intpr = Interpreter(rawModel, Interpreter.Options().apply {
-        setNumThreads(1)
-    })
-    intpr.run(inputBuffer, output)
-    intpr.close()
+
+    intpreter.runThreadSafe(inputBuffer, output)
 
     // calculate tempered softmax
     val flattened = output[0][0].flattened()
@@ -116,11 +113,7 @@ fun Bitmap.debugHeatMap(
         }
 }
 
-private val intpreter by lazy {
-    Interpreter(rawModel, Interpreter.Options().apply {
-        setNumThreads(1)
-    })
-}
+
 
 @Synchronized
 fun Interpreter.runThreadSafe(inputBuffer: ByteBuffer, output: Array<Array<Array<FloatArray>>>) {

--- a/glimpse-core/src/main/java/glimpse/core/models.kt
+++ b/glimpse-core/src/main/java/glimpse/core/models.kt
@@ -1,3 +1,9 @@
 package glimpse.core
 
-internal val rawModel by lazy { IOUtils.loadModel(Glimpse.client.applicationContext, "model.tflite") }
+import org.tensorflow.lite.Interpreter
+
+private val rawModel by lazy { IOUtils.loadModel(Glimpse.client.applicationContext, "model.tflite") }
+
+internal val intpreter by lazy {
+    Interpreter(rawModel, Interpreter.Options())
+}


### PR DESCRIPTION
After [solving the issue](https://github.com/tensorflow/tensorflow/issues/26365) regarding interpreter lifecycle we think it's better (and we know is faster for inference) if keep a global single instance. 

We've decided for now to not close the instance because we think it could lead to more issues than it aims to prevent (consuming interpreter from a thread background -glide transformation- when it's already closed, adding `androidx.lifecycle` dependency to the core module)

Let's see what happens 🎉 